### PR TITLE
wrong thumbnail_path for an attachment

### DIFF
--- a/app/helpers/knowledgebase_helper.rb
+++ b/app/helpers/knowledgebase_helper.rb
@@ -3,6 +3,7 @@ module KnowledgebaseHelper
   include KnowledgebaseSettingsHelper
   include ActionView::Helpers::NumberHelper
   include RedmineCrm::TagsHelper
+  include ApplicationHelper
 
   def format_article_summary(article, format, options = {})
     output = case format


### PR DESCRIPTION
Hello!

Thanks for your work about latest version of Redmine! :)

When we try to use thumbnail image, it causes Internal Error.

Could you look this case please? 

Signed-off-by: Ji-Hyeon Gim <potatogim@gluesys.com>